### PR TITLE
Gossip and Racial Trait removal corrected on swap

### DIFF
--- a/src/RacialTraitSwap.cpp
+++ b/src/RacialTraitSwap.cpp
@@ -193,7 +193,7 @@ public:
 
     npc_race_trait_swap() : CreatureScript("npc_race_trait_swap") { }
 
-    bool OnGossipHello(Player* player, Creature* creature)
+    bool OnGossipHello(Player* player, Creature* creature) override
     {
         char const* localizedEntry;
         switch (player->GetSession()->GetSessionDbcLocale())


### PR DESCRIPTION
Gossip was not working properly.
Racial Traits of other races were not being correctly removed when purchasing.