### PR TITLE
Fix Warrior Learning - Gift of the Naaru

### DIFF
--- a/src/RacialTraitSwap.cpp
+++ b/src/RacialTraitSwap.cpp
@@ -857,7 +857,7 @@ public:
                 player->learnSpell(59547, false);//Gift of Naaru
                 player->learnSpell(59540, false);//Shadow Resistance
             }
-            if (player->getClass() == CLASS_SHAMAN)
+            if (player->getClass() == CLASS_WARRIOR)
             {
                 player->learnSpell(28880, false);//Gift of Naaru
                 player->learnSpell(59221, false);//Shadow Resistance


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Replace second instance of Class_Shaman check in learning the Draenei racials.
Added Class_Warrior check to match the Warrior version of the spell.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Gift of the Naaru not learned by Warriors

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
https://www.wowhead.com/spell=28880/gift-of-the-naaru

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Not tested, very simple change

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a warrior (not Draenei)
2. Change racial to Draenei 
3. Confirm Gift of the Naaru is learned
