### PR TITLE
fix: remove deprecated creature_template columns from SQL

### DIFF
--- a/data/sql/db-world/base/world.RTS.sql
+++ b/data/sql/db-world/base/world.RTS.sql
@@ -4,8 +4,7 @@ SET @SUBNAME := 'AzerothCore Racial Traits Swapper';
 SET @DISPLAY_ID := 19646;
 
 DELETE FROM `creature_template` WHERE `entry`=98888;
-INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `scale`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES
-(98888, @NAME, @SUBNAME, 'Speak', 0, 80, 80, 35, 1, 1, 1.14286, 1, 0, 1, 0, 7, 138936390, 1, 0, 'npc_race_trait_swap');
+INSERT INTO `creature_template` (`entry`, `name`, `subname`, `IconName`, `gossip_menu_id`, `minlevel`, `maxlevel`, `faction`, `npcflag`, `speed_walk`, `speed_run`, `rank`, `unit_class`, `unit_flags`, `type`, `type_flags`, `RegenHealth`, `flags_extra`, `ScriptName`) VALUES(98888, @NAME, @SUBNAME, 'Speak', 0, 80, 80, 35, 1, 1, 1.14286, 0, 1, 0, 7, 138936390, 1, 0, 'npc_race_trait_swap');
 
 DELETE FROM `creature_template_model` WHERE `CreatureID` = 98888;
 INSERT INTO `creature_template_model` (`CreatureID`, `Idx`, `CreatureDisplayID`, `DisplayScale`, `Probability`, `VerifiedBuild`) VALUES


### PR DESCRIPTION
## Summary
- Removes `scale`, `mechanic_immune_mask`, and/or `spell_school_immune_mask` columns from `creature_template` INSERT/UPDATE statements
- These columns were removed from AzerothCore's `creature_template` table:
  - `scale` → moved to `creature_template_model.DisplayScale`
  - `mechanic_immune_mask`/`spell_school_immune_mask` → replaced by `CreatureImmunitiesId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)